### PR TITLE
Email notifications

### DIFF
--- a/config.js
+++ b/config.js
@@ -14,6 +14,14 @@ try {
 		cms: process.env.CMS_API_TOKEN,
 		service_url: process.env.SERVICE_URL,
 		cas_dev_mode: false,
-		cas_dev_mode_user: ''
+		cas_dev_mode_user: '',
+		email: {
+			username: process.env.EMAIL_USER,
+			password: process.env.EMAIL_PASSWORD,
+			from: process.env.EMAIL_FROM,
+			host: process.env.EMAIL_HOST,
+			secure: true,
+			port: 465
+		}
 	};
 }

--- a/devconfig.example.js
+++ b/devconfig.example.js
@@ -28,7 +28,7 @@ module.exports = {
     email: {
         username: '',
         password: '',
-        from: 'Rules and Elections Committee <rne@rpi.edu>',
+        from: 'Elections Website <rne@rpi.edu>',
         host: '',
         secure: true,
         port: 465

--- a/devconfig.example.js
+++ b/devconfig.example.js
@@ -30,6 +30,7 @@ module.exports = {
         password: '',
         from: 'Rules and Elections Committee <rne@rpi.edu>',
         host: '',
-        domain: ''
+        secure: true,
+        port: 465
     }
 };

--- a/devconfig.example.js
+++ b/devconfig.example.js
@@ -28,7 +28,7 @@ module.exports = {
     email: {
         username: '',
         password: '',
-        from: 'Elections Website <rne@rpi.edu>',
+        from: 'RPI Elections <rne@rpi.edu>',
         host: '',
         secure: true,
         port: 465

--- a/devconfig.example.js
+++ b/devconfig.example.js
@@ -11,6 +11,7 @@
  *  https://cms.union.rpi.edu or contact the Rensselaer Union Systems Administrators.
  *  - service_url: the url (and port, if not 80) that the user is accessing your app from; used by the RPI Central
  *  Authentication System
+ *  - email: settings required to connect to an SMTP relay
  */
 
 module.exports = {
@@ -23,5 +24,12 @@ module.exports = {
     cms: '',
     service_url: 'http://localhost:3000',
     cas_dev_mode: false,
-    cas_dev_mode_user: ''
+    cas_dev_mode_user: '',
+    email: {
+        username: '',
+        password: '',
+        from: 'Rules and Elections Committee <rne@rpi.edu>',
+        host: '',
+        domain: ''
+    }
 };

--- a/functions.js
+++ b/functions.js
@@ -1,7 +1,9 @@
 var db = require('./config.js').db,
     mysql = require('mysql'),
     cms = require('./cms.js'),
-    db_name = mysql.escapeId(require('./config.js').db_name);
+    db_name = mysql.escapeId(require('./config.js').db_name),
+    email = require('./config.js').email,
+    nodemailer = require('nodemailer');
 
 module.exports = {
     dbConnect: function (res) {
@@ -75,5 +77,14 @@ module.exports = {
     determineCMSPromise: function(rcs_id) {
         console.log(rcs_id);
         return isNaN(parseInt(rcs_id)) ? cms.getRCS(rcs_id) : cms.getRIN(rcs_id);
-    }
+    },
+    mailer: nodemailer.createTransport({
+        host: email.host,
+        port: email.port,
+        secure: email.secure,
+        auth: {
+            user: email.username,
+            pass: email.password
+        }
+    })
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2276 @@
+{
+  "name": "elections",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "angular": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.5.0.tgz",
+      "integrity": "sha1-2W7perbfbP0JFazL7khNCYrbdOw="
+    },
+    "assertion-error": {
+      "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz",
+      "integrity": "sha1-NaruwzCX8R9COZ7K3zP6zNJ/XEw=",
+      "dev": true
+    },
+    "bignumber.js": {
+      "version": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.1.2.tgz",
+      "integrity": "sha1-WzRlEzOn4IizrCMKMeJldOfG0KY="
+    },
+    "body-parser": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
+      "integrity": "sha1-wIzzMMM1jhUQFqBXRvE/ApyX+pc=",
+      "requires": {
+        "bytes": "2.1.0",
+        "content-type": "1.0.1",
+        "debug": "2.2.0",
+        "depd": "1.0.1",
+        "http-errors": "1.3.1",
+        "iconv-lite": "0.4.11",
+        "on-finished": "2.3.0",
+        "qs": "4.0.0",
+        "raw-body": "2.1.5",
+        "type-is": "1.6.11"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
+          "integrity": "sha1-rJPEEOL/ycx89LRks4KJBn9eR7Q="
+        },
+        "content-type": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
+          "integrity": "sha1-oZ0iRzJ9wDgFDOYit6FU7FnF5gA="
+        },
+        "depd": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+          "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
+        },
+        "http-errors": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+          "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+          "requires": {
+            "inherits": "2.0.1",
+            "statuses": "1.2.1"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+            },
+            "statuses": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+              "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg="
+            }
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.11",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
+          "integrity": "sha1-LstC/SlHRJIiCaLnxATayHk9it4="
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+          "requires": {
+            "ee-first": "1.1.1"
+          },
+          "dependencies": {
+            "ee-first": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+              "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+            }
+          }
+        },
+        "qs": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+          "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc="
+        },
+        "raw-body": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.5.tgz",
+          "integrity": "sha1-i+jwnd79DXKtmdiDq38Mw1BCCVY=",
+          "requires": {
+            "bytes": "2.2.0",
+            "iconv-lite": "0.4.13",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "bytes": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+              "integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg="
+            },
+            "iconv-lite": {
+              "version": "0.4.13",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+              "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
+            },
+            "unpipe": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+            }
+          }
+        },
+        "type-is": {
+          "version": "1.6.11",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
+          "integrity": "sha1-QuzeeXDyNjc4uYbANR77papTFkg=",
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "2.1.10"
+          },
+          "dependencies": {
+            "media-typer": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+              "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+            },
+            "mime-types": {
+              "version": "2.1.10",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+              "integrity": "sha1-uTx8tDYuFtQQcqflRTj7TUMHCDc=",
+              "requires": {
+                "mime-db": "1.22.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.22.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+                  "integrity": "sha1-qyOmNy3J2G09yRIb0OvTgQWhkEo="
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "bootstrap": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.6.tgz",
+      "integrity": "sha1-jej3SdyKdD8qxbUQ2Yg3Hj2qZYk="
+    },
+    "bower": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.7.7.tgz",
+      "integrity": "sha1-L9f/Pr3Lpaj/zYTDl8j9/p+CX5I="
+    },
+    "cas-authentication": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/cas-authentication/-/cas-authentication-0.0.8.tgz",
+      "integrity": "sha1-iPRvFvMJKJnKfJs1GXPwVxsV4gA=",
+      "requires": {
+        "xml2js": "0.4.16"
+      },
+      "dependencies": {
+        "xml2js": {
+          "version": "0.4.16",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.16.tgz",
+          "integrity": "sha1-+C/M0vlUDX4Km12sFj50cRlcnbM=",
+          "requires": {
+            "sax": "1.1.5",
+            "xmlbuilder": "4.2.1"
+          },
+          "dependencies": {
+            "sax": {
+              "version": "1.1.5",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz",
+              "integrity": "sha1-HaUKjQDN7NWUBWWfX/hTSf53N0M="
+            },
+            "xmlbuilder": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+              "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+              "requires": {
+                "lodash": "4.5.1"
+              },
+              "dependencies": {
+                "lodash": {
+                  "version": "4.5.1",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.5.1.tgz",
+                  "integrity": "sha1-gOigdMpfOJOmscELKmNkktcQwxY="
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "chai": {
+      "version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz",
+        "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+      }
+    },
+    "cookie-parser": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
+      "integrity": "sha1-nXVVcPtdF4kHcSJ6AjFNm+fPg1Y=",
+      "requires": {
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
+          "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU="
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+        }
+      }
+    },
+    "core-util-is": {
+      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "requires": {
+        "ms": "0.7.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        }
+      }
+    },
+    "deep-eql": {
+      "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "depd": {
+      "version": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+    },
+    "ejs": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.4.1.tgz",
+      "integrity": "sha1-guFbGyoflIsYCXR2uivXxm9NFWY="
+    },
+    "express": {
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
+      "integrity": "sha1-PAt288d1kMg0VzkGHsC9O6Bn7CQ=",
+      "requires": {
+        "accepts": "1.2.13",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.1",
+        "content-type": "1.0.1",
+        "cookie": "0.1.5",
+        "cookie-signature": "1.0.6",
+        "debug": "2.2.0",
+        "depd": "1.1.0",
+        "escape-html": "1.0.3",
+        "etag": "1.7.0",
+        "finalhandler": "0.4.1",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "1.0.10",
+        "qs": "4.0.0",
+        "range-parser": "1.0.3",
+        "send": "0.13.1",
+        "serve-static": "1.10.2",
+        "type-is": "1.6.11",
+        "utils-merge": "1.0.0",
+        "vary": "1.0.1"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+          "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+          "requires": {
+            "mime-types": "2.1.10",
+            "negotiator": "0.5.3"
+          },
+          "dependencies": {
+            "mime-types": {
+              "version": "2.1.10",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+              "integrity": "sha1-uTx8tDYuFtQQcqflRTj7TUMHCDc=",
+              "requires": {
+                "mime-db": "1.22.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.22.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+                  "integrity": "sha1-qyOmNy3J2G09yRIb0OvTgQWhkEo="
+                }
+              }
+            },
+            "negotiator": {
+              "version": "0.5.3",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+              "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g="
+            }
+          }
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+        },
+        "content-disposition": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+          "integrity": "sha1-h0dsamfI2qh+Muh2Ft+IO6f7Bxs="
+        },
+        "content-type": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
+          "integrity": "sha1-oZ0iRzJ9wDgFDOYit6FU7FnF5gA="
+        },
+        "cookie": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
+          "integrity": "sha1-armUiksa4hlSzSWIUwpHItQETXw="
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+        },
+        "depd": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+        },
+        "etag": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+          "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+        },
+        "finalhandler": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+          "integrity": "sha1-haF8bFmpRxfSYtYSMNSw6+PUoU0=",
+          "requires": {
+            "debug": "2.2.0",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "unpipe": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+            }
+          }
+        },
+        "fresh": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+          "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+        },
+        "methods": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+          "requires": {
+            "ee-first": "1.1.1"
+          },
+          "dependencies": {
+            "ee-first": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+              "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+            }
+          }
+        },
+        "parseurl": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+          "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        },
+        "proxy-addr": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
+          "integrity": "sha1-DUCoL4Afw1VWfS7LZe/j8HfxIcU=",
+          "requires": {
+            "forwarded": "0.1.0",
+            "ipaddr.js": "1.0.5"
+          },
+          "dependencies": {
+            "forwarded": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+              "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
+            },
+            "ipaddr.js": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
+              "integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c="
+            }
+          }
+        },
+        "qs": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+          "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc="
+        },
+        "range-parser": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+          "integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU="
+        },
+        "send": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+          "integrity": "sha1-ow1fTILIqbrprQCh2bG9vm8Zntc=",
+          "requires": {
+            "debug": "2.2.0",
+            "depd": "1.1.0",
+            "destroy": "1.0.4",
+            "escape-html": "1.0.3",
+            "etag": "1.7.0",
+            "fresh": "0.3.0",
+            "http-errors": "1.3.1",
+            "mime": "1.3.4",
+            "ms": "0.7.1",
+            "on-finished": "2.3.0",
+            "range-parser": "1.0.3",
+            "statuses": "1.2.1"
+          },
+          "dependencies": {
+            "destroy": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+              "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+            },
+            "http-errors": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+              "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+              "requires": {
+                "inherits": "2.0.1",
+                "statuses": "1.2.1"
+              },
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                }
+              }
+            },
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+            },
+            "statuses": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+              "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg="
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz",
+          "integrity": "sha1-/rgA0OciEk3QsAMzFgwW6cqovLM=",
+          "requires": {
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.1",
+            "send": "0.13.1"
+          }
+        },
+        "type-is": {
+          "version": "1.6.11",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
+          "integrity": "sha1-QuzeeXDyNjc4uYbANR77papTFkg=",
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "2.1.10"
+          },
+          "dependencies": {
+            "media-typer": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+              "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+            },
+            "mime-types": {
+              "version": "2.1.10",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+              "integrity": "sha1-uTx8tDYuFtQQcqflRTj7TUMHCDc=",
+              "requires": {
+                "mime-db": "1.22.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.22.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+                  "integrity": "sha1-qyOmNy3J2G09yRIb0OvTgQWhkEo="
+                }
+              }
+            }
+          }
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+        },
+        "vary": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+          "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA="
+        }
+      }
+    },
+    "express-mysql-session": {
+      "version": "https://registry.npmjs.org/express-mysql-session/-/express-mysql-session-1.0.0-rc.0.tgz",
+      "integrity": "sha1-hIdDdD/8t7mycIwSWcMEF8Ujr/I=",
+      "requires": {
+        "debug": "2.2.0",
+        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+        "express-session": "1.13.0",
+        "mysql-connection-manager": "https://registry.npmjs.org/mysql-connection-manager/-/mysql-connection-manager-0.0.12.tgz"
+      }
+    },
+    "express-session": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.13.0.tgz",
+      "integrity": "sha1-isO1wBiLSDgoUdiCB7jndG77QBE=",
+      "requires": {
+        "cookie": "0.2.3",
+        "cookie-signature": "1.0.6",
+        "crc": "3.4.0",
+        "debug": "2.2.0",
+        "depd": "1.1.0",
+        "on-headers": "1.0.1",
+        "parseurl": "1.3.1",
+        "uid-safe": "2.0.0",
+        "utils-merge": "1.0.0"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.2.3.tgz",
+          "integrity": "sha1-GllTavaFN6IReKATRvh8sFnSrlw="
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+        },
+        "crc": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.0.tgz",
+          "integrity": "sha1-QljjUWE6dO8RU9/LBeggw+lxXX8="
+        },
+        "depd": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+        },
+        "on-headers": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+          "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+        },
+        "parseurl": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+          "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+        },
+        "uid-safe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
+          "integrity": "sha1-p/PGymSh9qXQTsDvPkw9U2cxcTc=",
+          "requires": {
+            "base64-url": "1.2.1"
+          },
+          "dependencies": {
+            "base64-url": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+              "integrity": "sha1-GZ/WYXAqDnt9yubgaYuwicUvbXg="
+            }
+          }
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+        }
+      }
+    },
+    "font-awesome": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.5.0.tgz",
+      "integrity": "sha1-Hp18z31jvb5XAA4Y1RiMslV+cPg="
+    },
+    "inherits": {
+      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+    },
+    "isarray": {
+      "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "istanbul": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.2.tgz",
+      "integrity": "sha1-dl5yi5RVvt222qe5zsS5w8Pt5Ic=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.7",
+        "async": "1.5.2",
+        "escodegen": "1.7.1",
+        "esprima": "2.7.2",
+        "fileset": "0.2.1",
+        "handlebars": "4.0.5",
+        "js-yaml": "3.5.3",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.3.3",
+        "resolve": "1.1.7",
+        "supports-color": "3.1.2",
+        "which": "1.2.4",
+        "wordwrap": "1.0.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+          "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "escodegen": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
+          "integrity": "sha1-MOz89mypjcZ80v0WKr626vqM5vw=",
+          "dev": true,
+          "requires": {
+            "esprima": "1.2.5",
+            "estraverse": "1.9.3",
+            "esutils": "2.0.2",
+            "optionator": "0.5.0",
+            "source-map": "0.2.0"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+              "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
+              "dev": true
+            },
+            "estraverse": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+              "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+              "dev": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+              "dev": true
+            },
+            "optionator": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+              "dev": true,
+              "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "1.0.7",
+                "levn": "0.2.5",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "0.0.3"
+              },
+              "dependencies": {
+                "deep-is": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                  "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+                  "dev": true
+                },
+                "fast-levenshtein": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+                  "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+                  "dev": true
+                },
+                "levn": {
+                  "version": "0.2.5",
+                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                  "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+                  "dev": true,
+                  "requires": {
+                    "prelude-ls": "1.1.2",
+                    "type-check": "0.3.2"
+                  }
+                },
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                  "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+                  "dev": true
+                },
+                "type-check": {
+                  "version": "0.3.2",
+                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                  "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+                  "dev": true,
+                  "requires": {
+                    "prelude-ls": "1.1.2"
+                  }
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                  "dev": true
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "amdefine": "1.0.0"
+              },
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            }
+          }
+        },
+        "esprima": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
+          "integrity": "sha1-9DvlQ2CZhOrkTJM6xjNSpq818zk=",
+          "dev": true
+        },
+        "fileset": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
+          "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
+          "dev": true,
+          "requires": {
+            "glob": "5.0.15",
+            "minimatch": "2.0.10"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "dev": true,
+              "requires": {
+                "inflight": "1.0.4",
+                "inherits": "2.0.1",
+                "minimatch": "2.0.10",
+                "once": "1.3.3",
+                "path-is-absolute": "1.0.0"
+              },
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+                  "dev": true,
+                  "requires": {
+                    "once": "1.3.3",
+                    "wrappy": "1.0.1"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+                      "dev": true
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                  "dev": true
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.3"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE=",
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "0.3.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                      "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
+                      "dev": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "handlebars": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+          "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.6.2"
+          },
+          "dependencies": {
+            "optimist": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.10",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                  "dev": true
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                  "dev": true
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.0"
+              },
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                  "dev": true
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.6.2",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
+              "integrity": "sha1-9QvoikLNOWpiUdxSqzcvccwS/vA=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "async": "0.2.10",
+                "source-map": "0.5.3",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                  "dev": true,
+                  "optional": true
+                },
+                "source-map": {
+                  "version": "0.5.3",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+                  "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A=",
+                  "dev": true,
+                  "optional": true
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+                  "dev": true,
+                  "optional": true
+                },
+                "yargs": {
+                  "version": "3.10.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.1.2",
+                    "window-size": "0.1.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
+                        "wordwrap": "0.0.2"
+                      },
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.3",
+                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "align-text": "0.1.4",
+                            "lazy-cache": "1.0.3"
+                          },
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "kind-of": "3.0.2",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.5.2"
+                              },
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.0.2",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                  "integrity": "sha1-GH20JwRufpCUVpLmdoZovWkA3qA=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "is-buffer": "1.1.2"
+                                  },
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.2",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz",
+                                      "integrity": "sha1-+hImWI+gBIsAXEfk+xuxVV1e3qo=",
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            },
+                            "lazy-cache": {
+                              "version": "1.0.3",
+                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+                              "integrity": "sha1-6XdUYY+ciGu5mbL/aceLgkU9ZnQ=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "align-text": "0.1.4"
+                          },
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "kind-of": "3.0.2",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.5.2"
+                              },
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.0.2",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                  "integrity": "sha1-GH20JwRufpCUVpLmdoZovWkA3qA=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "is-buffer": "1.1.2"
+                                  },
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.2",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz",
+                                      "integrity": "sha1-+hImWI+gBIsAXEfk+xuxVV1e3qo=",
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.1.2",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+                      "integrity": "sha1-3Mk3J74gljLpiwJxjvTLeWAjIvI=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "escape-string-regexp": "1.0.5"
+                      },
+                      "dependencies": {
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.3.tgz",
+          "integrity": "sha1-6e5ggrBld3DkNG368qWMWZIlH3Y=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.6",
+            "esprima": "2.7.2"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.6.tgz",
+              "integrity": "sha1-raPEat5kaVkG77t6CjN/YZq7RpQ=",
+              "dev": true,
+              "requires": {
+                "sprintf-js": "1.0.3"
+              },
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.7"
+          }
+        },
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.1"
+          },
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+              "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+              "dev": true
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+              "dev": true
+            }
+          }
+        },
+        "which": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
+          "integrity": "sha1-FVf5YIBgTlsRs1meufRbUKnv1yI=",
+          "dev": true,
+          "requires": {
+            "is-absolute": "0.1.7",
+            "isexe": "1.1.2"
+          },
+          "dependencies": {
+            "is-absolute": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+              "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+              "dev": true,
+              "requires": {
+                "is-relative": "0.1.3"
+              },
+              "dependencies": {
+                "is-relative": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                  "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
+                  "dev": true
+                }
+              }
+            },
+            "isexe": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+              "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+              "dev": true
+            }
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
+      }
+    },
+    "jade": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
+      "integrity": "sha1-nIDlOMEtP7lcjZu5VZ+gzAQEBf0=",
+      "requires": {
+        "character-parser": "1.2.1",
+        "clean-css": "3.4.9",
+        "commander": "2.6.0",
+        "constantinople": "3.0.2",
+        "jstransformer": "0.0.2",
+        "mkdirp": "0.5.1",
+        "transformers": "2.1.0",
+        "uglify-js": "2.6.2",
+        "void-elements": "2.0.1",
+        "with": "4.0.3"
+      },
+      "dependencies": {
+        "character-parser": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz",
+          "integrity": "sha1-wN3kqxgnE7kZuXCVmhI+zBow/NY="
+        },
+        "clean-css": {
+          "version": "3.4.9",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.9.tgz",
+          "integrity": "sha1-lUxJw0lodj9QsF/Q3eRGlM+dLrk=",
+          "requires": {
+            "commander": "2.8.1",
+            "source-map": "0.4.4"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.8.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+              "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+              "requires": {
+                "graceful-readlink": "1.0.1"
+              },
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "requires": {
+                "amdefine": "1.0.0"
+              },
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM="
+                }
+              }
+            }
+          }
+        },
+        "commander": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+          "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0="
+        },
+        "constantinople": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
+          "integrity": "sha1-S5RdmTeQe82Y7ldRIsOBdRZUQUE=",
+          "requires": {
+            "acorn": "2.7.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+              "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
+            }
+          }
+        },
+        "jstransformer": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz",
+          "integrity": "sha1-eq4pqQPRls+glz2IXT5HlH7Ndqs=",
+          "requires": {
+            "is-promise": "2.1.0",
+            "promise": "6.1.0"
+          },
+          "dependencies": {
+            "is-promise": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+              "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+            },
+            "promise": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+              "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY=",
+              "requires": {
+                "asap": "1.0.0"
+              },
+              "dependencies": {
+                "asap": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
+                  "integrity": "sha1-sqRdpf36ILBJb8N2jMJ8EvqRan0="
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+            }
+          }
+        },
+        "transformers": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
+          "integrity": "sha1-XSPLNVYd2F3Gf7hIIwm0fVPM6ac=",
+          "requires": {
+            "css": "1.0.8",
+            "promise": "2.0.0",
+            "uglify-js": "2.2.5"
+          },
+          "dependencies": {
+            "css": {
+              "version": "1.0.8",
+              "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+              "integrity": "sha1-k4aBHKgrzMnuf7WnMrHioxfIo+c=",
+              "requires": {
+                "css-parse": "1.0.4",
+                "css-stringify": "1.0.5"
+              },
+              "dependencies": {
+                "css-parse": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
+                  "integrity": "sha1-OLBQP7+dqfVOnB29pg4UXHcRe90="
+                },
+                "css-stringify": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
+                  "integrity": "sha1-sNBClG2ylTu50pKQCmy19tASIDE="
+                }
+              }
+            },
+            "promise": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+              "integrity": "sha1-RmSKqdYFr10ucMMCS/WUNtoCuA4=",
+              "requires": {
+                "is-promise": "1.0.1"
+              },
+              "dependencies": {
+                "is-promise": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+                  "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU="
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.2.5",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+              "integrity": "sha1-puAqcNg5eSuXgEiLe4sYTAlcmcc=",
+              "requires": {
+                "optimist": "0.3.7",
+                "source-map": "0.1.43"
+              },
+              "dependencies": {
+                "optimist": {
+                  "version": "0.3.7",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+                  "requires": {
+                    "wordwrap": "0.0.3"
+                  },
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+                  "requires": {
+                    "amdefine": "1.0.0"
+                  },
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM="
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "uglify-js": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
+          "integrity": "sha1-9QvoikLNOWpiUdxSqzcvccwS/vA=",
+          "requires": {
+            "async": "0.2.10",
+            "source-map": "0.5.3",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+            },
+            "source-map": {
+              "version": "0.5.3",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.1.2",
+                "window-size": "0.1.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+                },
+                "cliui": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                  "requires": {
+                    "center-align": "0.1.3",
+                    "right-align": "0.1.3",
+                    "wordwrap": "0.0.2"
+                  },
+                  "dependencies": {
+                    "center-align": {
+                      "version": "0.1.3",
+                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                      "requires": {
+                        "align-text": "0.1.4",
+                        "lazy-cache": "1.0.3"
+                      },
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.4",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                          "requires": {
+                            "kind-of": "3.0.2",
+                            "longest": "1.0.1",
+                            "repeat-string": "1.5.2"
+                          },
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "3.0.2",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                              "integrity": "sha1-GH20JwRufpCUVpLmdoZovWkA3qA=",
+                              "requires": {
+                                "is-buffer": "1.1.2"
+                              },
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.2",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz",
+                                  "integrity": "sha1-+hImWI+gBIsAXEfk+xuxVV1e3qo="
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
+                            }
+                          }
+                        },
+                        "lazy-cache": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+                          "integrity": "sha1-6XdUYY+ciGu5mbL/aceLgkU9ZnQ="
+                        }
+                      }
+                    },
+                    "right-align": {
+                      "version": "0.1.3",
+                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                      "requires": {
+                        "align-text": "0.1.4"
+                      },
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.4",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                          "requires": {
+                            "kind-of": "3.0.2",
+                            "longest": "1.0.1",
+                            "repeat-string": "1.5.2"
+                          },
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "3.0.2",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                              "integrity": "sha1-GH20JwRufpCUVpLmdoZovWkA3qA=",
+                              "requires": {
+                                "is-buffer": "1.1.2"
+                              },
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.2",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz",
+                                  "integrity": "sha1-+hImWI+gBIsAXEfk+xuxVV1e3qo="
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+                  "integrity": "sha1-3Mk3J74gljLpiwJxjvTLeWAjIvI=",
+                  "requires": {
+                    "escape-string-regexp": "1.0.5"
+                  },
+                  "dependencies": {
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+                    }
+                  }
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+                }
+              }
+            }
+          }
+        },
+        "void-elements": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+          "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
+        },
+        "with": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
+          "integrity": "sha1-7v0VTp550sjTQXtkeo8U2f7M4U4=",
+          "requires": {
+            "acorn": "1.2.2",
+            "acorn-globals": "1.0.9"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+              "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ="
+            },
+            "acorn-globals": {
+              "version": "1.0.9",
+              "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+              "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
+              "requires": {
+                "acorn": "2.7.0"
+              },
+              "dependencies": {
+                "acorn": {
+                  "version": "2.7.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+                  "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "jquery": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.1.tgz",
+      "integrity": "sha1-PD4WhUrT0qxErGUCGxdCbSKtgD8="
+    },
+    "mime": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+    },
+    "mocha": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
+      "integrity": "sha1-FRdo3Sh161G8gpXpgAAm6fK7OY8=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.3",
+        "growl": "1.8.1",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+          "dev": true
+        },
+        "diff": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "2.0.3",
+            "inherits": "2.0.1",
+            "minimatch": "0.2.14"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+              "dev": true
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+              "dev": true,
+              "requires": {
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
+              },
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.7.3",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                  "dev": true
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "growl": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+          "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
+          "dev": true
+        },
+        "jade": {
+          "version": "0.26.3",
+          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+          "dev": true,
+          "requires": {
+            "commander": "0.6.1",
+            "mkdirp": "0.3.0"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+              "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+              "dev": true
+            },
+            "mkdirp": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+              "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+              "dev": true
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+          "dev": true
+        }
+      }
+    },
+    "morgan": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
+      "integrity": "sha1-X9gYOYxoGcuiinzWZk8pL+HAu/I=",
+      "requires": {
+        "basic-auth": "1.0.3",
+        "debug": "2.2.0",
+        "depd": "1.0.1",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
+      },
+      "dependencies": {
+        "basic-auth": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz",
+          "integrity": "sha1-QfVVI+WJQFA47jVnlYxipe1wVRo="
+        },
+        "depd": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+          "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+          "requires": {
+            "ee-first": "1.1.1"
+          },
+          "dependencies": {
+            "ee-first": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+              "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+            }
+          }
+        },
+        "on-headers": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+          "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+        }
+      }
+    },
+    "mysql": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.10.2.tgz",
+      "integrity": "sha1-nuXkbwVrK6OnhAoQ6uNCb1k4QpI=",
+      "requires": {
+        "bignumber.js": "2.1.4",
+        "readable-stream": "1.1.13"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.1.4.tgz",
+          "integrity": "sha1-KbO7aT27I46Ity6sL7iWUIiLLVk="
+        },
+        "readable-stream": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          },
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            }
+          }
+        }
+      }
+    },
+    "mysql-connection-manager": {
+      "version": "https://registry.npmjs.org/mysql-connection-manager/-/mysql-connection-manager-0.0.12.tgz",
+      "integrity": "sha1-p0m5y9jUMfRHnjhxWN939q5YGmo=",
+      "requires": {
+        "debug": "2.2.0",
+        "mysql": "https://registry.npmjs.org/mysql/-/mysql-2.10.0.tgz"
+      },
+      "dependencies": {
+        "mysql": {
+          "version": "https://registry.npmjs.org/mysql/-/mysql-2.10.0.tgz",
+          "integrity": "sha1-xeNvrOR9WSvFHxM0XsYUGnyncm8=",
+          "requires": {
+            "bignumber.js": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.1.2.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          }
+        }
+      }
+    },
+    "nodemailer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-4.1.0.tgz",
+      "integrity": "sha512-pZg74CNQgnC0gZTfH0btXCxjKj7/2v5pea6hmMJ/iKyT48Z81TXZua7c65clwqKIlWfMfYBQG3OkrKxycIdXTw=="
+    },
+    "q": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
+    },
+    "readable-stream": {
+      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+      "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+      "requires": {
+        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+      }
+    },
+    "serve-favicon": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz",
+      "integrity": "sha1-rtNsxoNAaabxicxyIsahqBHcWzk=",
+      "requires": {
+        "etag": "1.7.0",
+        "fresh": "0.3.0",
+        "ms": "0.7.1",
+        "parseurl": "1.3.1"
+      },
+      "dependencies": {
+        "etag": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+          "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+        },
+        "fresh": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+          "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        },
+        "parseurl": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+          "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "striptags": {
+      "version": "https://registry.npmjs.org/striptags/-/striptags-3.0.1.tgz",
+      "integrity": "sha1-SPDWkyVJxHuzWCkgyHUnz0mhYME="
+    },
+    "supertest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-1.2.0.tgz",
+      "integrity": "sha1-hQp5X5Bo0vrxngF5n/CZYuDOQ74=",
+      "dev": true,
+      "requires": {
+        "methods": "1.1.2",
+        "superagent": "1.7.2"
+      },
+      "dependencies": {
+        "methods": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+          "dev": true
+        },
+        "superagent": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.7.2.tgz",
+          "integrity": "sha1-Zfnu1PU2EyDJ2HRBKrd7666ktXI=",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.0",
+            "cookiejar": "2.0.6",
+            "debug": "2.2.0",
+            "extend": "3.0.0",
+            "form-data": "0.2.0",
+            "formidable": "1.0.17",
+            "methods": "1.1.2",
+            "mime": "1.3.4",
+            "qs": "2.3.3",
+            "readable-stream": "1.0.27-1",
+            "reduce-component": "1.0.1"
+          },
+          "dependencies": {
+            "component-emitter": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
+              "integrity": "sha1-zNETqGOI0GSC0D3j/H35hSa6jv4=",
+              "dev": true
+            },
+            "cookiejar": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
+              "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4=",
+              "dev": true
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "dev": true
+            },
+            "form-data": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
+              "dev": true,
+              "requires": {
+                "async": "0.9.2",
+                "combined-stream": "0.0.7",
+                "mime-types": "2.0.14"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "0.9.2",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                  "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+                  "dev": true
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+                  "dev": true,
+                  "requires": {
+                    "delayed-stream": "0.0.5"
+                  },
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "mime-types": {
+                  "version": "2.0.14",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                  "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+                  "dev": true,
+                  "requires": {
+                    "mime-db": "1.12.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.12.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                      "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "formidable": {
+              "version": "1.0.17",
+              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+              "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk=",
+              "dev": true
+            },
+            "qs": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+              "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.0.27-1",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+              "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                  "dev": true
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                  "dev": true
+                }
+              }
+            },
+            "reduce-component": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+              "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "type-detect": {
+      "version": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "q": "^1.4.1",
     "serve-favicon": "~2.3.0",
     "striptags": "^3.0.1",
-    "uid2": "0.0.3"
+    "uid2": "0.0.3",
+    "emailjs":"^1.0.11"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "serve-favicon": "~2.3.0",
     "striptags": "^3.0.1",
     "uid2": "0.0.3",
-    "emailjs":"^1.0.11"
+    "nodemailer": "^4.0.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/routes/ama.js
+++ b/routes/ama.js
@@ -101,10 +101,10 @@ router.post('/candidate/:rcs_id', function (req, res) {
     connection.query(query, functions.defaultJSONCallback(res));
 
     let mailoptions = {
-        text: "The following question has been asked on your profile: \n" +
-        data.question_text + "\n \n" +
-        "You will recieve this email every time a new AMA question has been added to your profile. \n" +
-        "If you believe this question is a spam submission, please report it to the Rules and Elections Committee by emailing rne@rpi.edu \n" +
+        text: "The following question has been asked on your profile:\n" +
+        data.question_text + "\n\n" +
+        "You will recieve this email every time a new AMA question has been added to your profile.\n" +
+        "If you believe this question is a spam submission, please report it to the Rules and Elections Committee by emailing rne@rpi.edu\n" +
         "This was an automated email sent by the Elections Website at https://elections.union.rpi.edu",
         from: email.from,
         to: candidate_rcs_id + "@rpi.edu",

--- a/routes/ama.js
+++ b/routes/ama.js
@@ -111,7 +111,7 @@ router.post('/candidate/:rcs_id', function (req, res) {
         subject: "New AMA Question"
     };
 
-    transporter.sendMail(mailOptions, (error, info) => {
+    transporter.sendMail(mailoptions, (error, info) => {
         if (error) {
             return console.log(error);
         }

--- a/routes/assistants.js
+++ b/routes/assistants.js
@@ -103,7 +103,7 @@ router.post('/create/:candidate_rcs/:assistant_rcs', function (req, res) {
                     subject: "Candidate Assistant Added"
                 };
 
-                transporter.sendMail(mailOptions, (error, info) => {
+                transporter.sendMail(mailoptions, (error, info) => {
                     if (error) {
                         return console.log(error);
                     }

--- a/routes/assistants.js
+++ b/routes/assistants.js
@@ -95,7 +95,7 @@ router.post('/create/:candidate_rcs/:assistant_rcs', function (req, res) {
                     " as an assistant for " + candidate_rcs);
                 
                 let mailoptions = {
-                    text: cms_data.first_name + " " + cms_data.last_name + "has been added as your candidate assistant.\n" +
+                    text: cms_data.first_name + " " + cms_data.last_name + " has been added as your candidate assistant.\n" +
                     "You will recieve this email every time a candidate assistant is added to your profile.\n" +
                     "This was an automated email sent by the Elections Website at https://elections.union.rpi.edu",
                     from: email.from,

--- a/routes/assistants.js
+++ b/routes/assistants.js
@@ -4,8 +4,8 @@ var express = require('express'),
     functions = require('../functions.js'),
     cms = require('../cms.js'),
     logger = require('../logger.js'),
-    email = require('../config.js').email,
-    nodemailer = require('nodemailer');
+    config = require('../config.js'),
+    mailer = functions.mailer;
 
 var queries = {
     all: "SELECT * FROM `assistants`",
@@ -14,16 +14,6 @@ var queries = {
     "`middle_name`, `last_name`,  `preferred_name`, `rin`) VALUES ",
     remove: "DELETE FROM " + functions.dbName() + ".`assistants`"
 };
-
-let transporter = nodemailer.createTransport({
-    host: email.host,
-    port: email.port,
-    secure: email.secure,
-    auth: {
-        user: email.username,
-        pass: email.password
-    }
-});
 
 router.get('/', function (req, res) {
     var connection = functions.dbConnect(res);
@@ -93,17 +83,17 @@ router.post('/create/:candidate_rcs/:assistant_rcs', function (req, res) {
 
                 logger.write(connection, req.session.cas_user, "ASSISTANT_CREATE", "Added " + cms_data.username +
                     " as an assistant for " + candidate_rcs);
-                
+
                 let mailoptions = {
-                    text: cms_data.first_name + " " + cms_data.last_name + " has been added as your candidate assistant.\n" +
-                    "You will recieve this email every time a candidate assistant is added to your profile.\n" +
-                    "This was an automated email sent by the Elections Website at https://elections.union.rpi.edu",
-                    from: email.from,
+                    text: cms_data.first_name + " " + cms_data.last_name + " has been added as your candidate assistant. " +
+                    "You will receive this email every time a candidate assistant is added to your profile.\n\n" +
+                    "This is an automated email sent by the Elections website at https://elections.union.rpi.edu",
+                    from: config.email.from,
                     to: candidate_rcs + "@rpi.edu",
-                    subject: "Candidate Assistant Added"
+                    subject: "Candidate assistant added"
                 };
 
-                transporter.sendMail(mailoptions, (error, info) => {
+                mailer.sendMail(mailoptions, (error, info) => {
                     if (error) {
                         return console.log(error);
                     }

--- a/routes/assistants.js
+++ b/routes/assistants.js
@@ -96,7 +96,7 @@ router.post('/create/:candidate_rcs/:assistant_rcs', function (req, res) {
                 
                 let mailoptions = {
                     text: cms_data.first_name + " " + cms_data.last_name + "has been added as your candidate assistant.\n" +
-                    "You will recieve this email every time a candidate assistant is added to your profile. \n" +
+                    "You will recieve this email every time a candidate assistant is added to your profile.\n" +
                     "This was an automated email sent by the Elections Website at https://elections.union.rpi.edu",
                     from: email.from,
                     to: candidate_rcs + "@rpi.edu",

--- a/routes/candidates.js
+++ b/routes/candidates.js
@@ -64,8 +64,9 @@ var queries = {
 var server = emailjs.server.connect({
     user: email.user,
     password: email.password,
-    host: 'mail.rpi.edu',
-    ssl: email.ssl
+    host: email.host,
+    tls: email.ssl,
+    domain: email.domain
 });
 
 var processMiscInfo = function (result) {
@@ -280,10 +281,11 @@ router.post('/create/:rcs_id/:office_id', function (req, res) {
                 " as a candidate for office #" + office_id);
 
             server.send({
-                text: "Your profile on the Elections website has been activated.\n" +
-                "You can sign into the Elections website with your RCS ID and edit your page here: https://elections.union.rpi.edu/raabd \n" +
+                text: "Hello " + cms_data.first_name + ",\n" +
+                "Your profile on the Elections website has been activated.\n" +
+                "You can sign into the Elections website with your RCS ID and edit your page here: https://elections.union.rpi.edu/" + cms_data.username + " \n" +
                 "If you are running for more than one office, you will get this email every time a new office is added to your profile. \n" +
-                "This was an automated email sent by the Elections Website at elections.union.rpi.edu",
+                "This was an automated email sent by the Elections Website at https://elections.union.rpi.edu",
                 from: email.from,
                 to: cms_data.username + "@rpi.edu",
                 subject: "Elections Profile Created"

--- a/routes/candidates.js
+++ b/routes/candidates.js
@@ -284,14 +284,14 @@ router.post('/create/:rcs_id/:office_id', function (req, res) {
                 " as a candidate for office #" + office_id);
 
             let mailoptions = {
-                text: "Hello " + cms_data.first_name + ",\n \n" +
-                "Your profile on the Elections website has been activated.\n" +
-                "You can sign into the Elections website with your RCS ID and edit your page here: https://elections.union.rpi.edu/candidate/" + cms_data.username + " \n" +
-                "If you are running for more than one office, you will get this email every time a new office is added to your profile. \n" +
+                text: "Hello " + cms_data.first_name + ",\n\n" +
+                "Your have been added to a new office on the Elections website.\n" +
+                "You can sign into the Elections website with your RCS ID and edit your page here: https://elections.union.rpi.edu/candidate/" + cms_data.username + "\n" +
+                "If you are running for more than one office, you will get this email every time a new office is added to your profile.\n" +
                 "This was an automated email sent by the Elections Website at https://elections.union.rpi.edu",
                 from: email.from,
                 to: cms_data.username + "@rpi.edu",
-                subject: "Elections Profile Created"
+                subject: "Added to Office"
             };
 
             transporter.sendMail(mailOptions, (error, info) => {

--- a/routes/candidates.js
+++ b/routes/candidates.js
@@ -294,7 +294,7 @@ router.post('/create/:rcs_id/:office_id', function (req, res) {
                 subject: "Added to Office"
             };
 
-            transporter.sendMail(mailOptions, (error, info) => {
+            transporter.sendMail(mailoptions, (error, info) => {
                 if (error) {
                     return console.log(error);
                 }

--- a/routes/candidates.js
+++ b/routes/candidates.js
@@ -10,7 +10,7 @@ var express = require('express'),
     path = require('path')
     striptags = require('striptags'),
     email = require('../config.js').email,
-    emailjs = require('emailjs');
+    nodemailer = require('nodemailer');
 
 var IMAGE_TYPES = ['image/jpeg', 'image/png'];
 var TARGET_PATH = path.resolve(__dirname, '../public/usr_content');
@@ -61,13 +61,16 @@ var queries = {
     listRCS: "SELECT `rcs_id` FROM `candidates` WHERE election_id = (SELECT `value` FROM `configurations` WHERE `key` = 'active_election_id');"
 };
 
-var server = emailjs.server.connect({
-    user: email.user,
-    password: email.password,
+let transporter = nodemailer.createTransport({
     host: email.host,
-    tls: email.ssl,
-    domain: email.domain
+    port: email.port,
+    secure: email.secure,
+    auth: {
+        user: email.username,
+        pass: email.password
+    }
 });
+
 
 var processMiscInfo = function (result) {
     for(var r=0; r < result.length; r++) {
@@ -280,16 +283,23 @@ router.post('/create/:rcs_id/:office_id', function (req, res) {
             logger.write(connection, req.session.cas_user, "CANDIDATE_CREATE", "Added " + cms_data.username +
                 " as a candidate for office #" + office_id);
 
-            server.send({
-                text: "Hello " + cms_data.first_name + ",\n" +
+            let mailoptions = {
+                text: "Hello " + cms_data.first_name + ",\n \n" +
                 "Your profile on the Elections website has been activated.\n" +
-                "You can sign into the Elections website with your RCS ID and edit your page here: https://elections.union.rpi.edu/" + cms_data.username + " \n" +
+                "You can sign into the Elections website with your RCS ID and edit your page here: https://elections.union.rpi.edu/candidate/" + cms_data.username + " \n" +
                 "If you are running for more than one office, you will get this email every time a new office is added to your profile. \n" +
                 "This was an automated email sent by the Elections Website at https://elections.union.rpi.edu",
                 from: email.from,
                 to: cms_data.username + "@rpi.edu",
                 subject: "Elections Profile Created"
-            }, function(err, message) { console.log(err || message); });
+            };
+
+            transporter.sendMail(mailOptions, (error, info) => {
+                if (error) {
+                    return console.log(error);
+                }
+                console.log('Message %s sent: %s', info.messageId, info.response);
+            });
 
             connection.end();
         } catch (e) {


### PR DESCRIPTION
I've implemented very basic email notifications that send an email when a candidate is added to the site (that API route is also used when an office is added to a candidate), when an AMA question is asked, and when a candidate assistant is added to their profile. These 3 cases are ready to be merged, and I've tested them with the RPI SMTP credentials for rne@rpi.edu - because I was the one to provision them ;) . You can't opt-out of these emails which is okay because they're going to your RPI email.

The nominations email case is something I definitely want to do, but I feel like if I do it every time the page is submitted, I'm going to fill people's inboxes. Should there be an interval where an email is sent say once every hour of submitting nominations? I would think that would require adding a table to the database to track when the last email was sent so I was going to wait on that one for some more feedback.