### PR TITLE
Redirect users to previous page after sign in

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,7 +76,15 @@ app.use('/api/static', static_routes);
 app.use('/api/settings', settings);
 app.use('/api/elections', elections);
 
-app.get('/login', cas.bounce, function (req, res) {
+app.get('/login', function (req, res, next) {
+    // store page to redirect to in session
+    if (req.query.redirect) {
+      req.session.redirect = req.query.redirect;
+    }
+    next();
+  },
+  cas.bounce,
+  function (req, res) {
     if (!req.session || !req.session.cas_user) {
         res.redirect('/logout');
     }
@@ -103,7 +111,10 @@ app.get('/login', cas.bounce, function (req, res) {
         req.session.admin_rights = wtg_status || rne_status;
         req.session.is_authenticated = true;
 
-        res.redirect('/');
+        // redirect to stored page, if exists
+        const redirect = req.session.redirect || '/';
+        delete req.session.redirect;
+        res.redirect(redirect);
     });
 });
 app.get('/logout', cas.logout);

--- a/public/components/Main/MainController.js
+++ b/public/components/Main/MainController.js
@@ -77,4 +77,8 @@ app.controller('MainController', ['$scope', '$location', '$http', '$templateCach
 
         return Math.round((obtained / required) * 100) + '%';
     };
+
+    $scope.loginURL = function () {
+      return '/login?redirect=' + encodeURIComponent($location.path());
+    };
 }]);

--- a/public/components/Main/index.html
+++ b/public/components/Main/index.html
@@ -47,7 +47,7 @@
             </ul>
             <ul class="nav navbar-nav navbar-right">
                 <li ng-if="!authenticated">
-                    <a href="/login" target="_self">
+                    <a ng-href="{{ loginURL() }}" target="_self">
                         <span ng-if="maintenanceMode">Admin sign in</span>
                         <span ng-else>Sign in</span>
                     </a>

--- a/public/components/Main/index.html
+++ b/public/components/Main/index.html
@@ -48,9 +48,8 @@
             <ul class="nav navbar-nav navbar-right">
                 <li ng-if="!authenticated">
                     <a href="/login" target="_self">
-                        <span ng-if="!maintenanceMode">Candidate</span>
-                        <span ng-if="maintenanceMode">Admin</span>
-                        Login
+                        <span ng-if="maintenanceMode">Admin sign in</span>
+                        <span ng-else>Sign in</span>
                     </a>
                 </li>
                 <li class="dropdown" ng-if="authenticated">


### PR DESCRIPTION
Does what it says on the tin.

We dynamically generate a login link on the frontend to include a `redirect` query parameter with the current page. Then, the login handler stores that value in the user's session, does the CAS bounce, and then reads the redirect value out of the session and returns a redirect to it (or `/` if it doesn't exist in the session) and deletes the redirect value from the session.